### PR TITLE
Update build artifacts to v4

### DIFF
--- a/.github/workflows/gradle-build-linux-pr-staging.yml
+++ b/.github/workflows/gradle-build-linux-pr-staging.yml
@@ -1,7 +1,7 @@
 name: Gradle Build Linux On PR To Staging
 
 on:
-  pull_request:
+  push:
     branches:
       - staging
 

--- a/.github/workflows/gradle-build-linux-pr-staging.yml
+++ b/.github/workflows/gradle-build-linux-pr-staging.yml
@@ -1,0 +1,53 @@
+name: Gradle Build Linux On PR To Staging
+
+on:
+  pull_request:
+    branches:
+      - staging
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build
+  
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-artifacts
+        path: app/build/distributions/app.tar
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v0.1.beta
+        release_name: Release v0.1.beta
+        draft: true
+        prerelease: true
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: app/build/distributions/app.tar
+        asset_name: app.tar
+        asset_content_type: application/x-tar


### PR DESCRIPTION
GitHub deprecated build-artifacts Actions v1 through v3. Updated yml to use v4.